### PR TITLE
Ensure that redoc stays at its basepath

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/redoc/deployment/RedocConfigSerializer.java
+++ b/deployment/src/main/java/io/quarkiverse/redoc/deployment/RedocConfigSerializer.java
@@ -17,6 +17,9 @@ public class RedocConfigSerializer {
     public String serialize(RedocConfigModel config) {
         JsonObject json = new JsonObject();
 
+        if (config.routingBasePath() != null) {
+            json.put("routingBasePath", config.routingBasePath());
+        }
         if (config.hideDownloadButtons() != null) {
             json.put("hideDownloadButtons", config.hideDownloadButtons());
         }

--- a/deployment/src/main/java/io/quarkiverse/redoc/deployment/RedocProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/redoc/deployment/RedocProcessor.java
@@ -50,8 +50,13 @@ class RedocProcessor {
                     .toList();
         }
 
+        String routingBasePath = config.routingBasePath()
+                .filter(s -> !s.isEmpty())
+                .orElseGet(() -> nonApplicationRootPath.resolvePath(config.path()));
+
         return new RedocConfigBuildItem(new RedocConfigModel(
                 config.path(),
+                routingBasePath,
                 config.title(),
                 config.alwaysInclude(),
                 config.hideDownloadButtons().orElse(null),

--- a/deployment/src/main/java/io/quarkiverse/redoc/deployment/config/RedocConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/redoc/deployment/config/RedocConfig.java
@@ -24,6 +24,18 @@ public interface RedocConfig {
     String path();
 
     /**
+     * The base path of Redocly, combined with any other preceding path. Redocly performs URL manipulation when navigating to
+     * OpenAPI tags using the sidebar.
+     * <p/>
+     * Useful if this Quarkus application is served behind a reverse proxy which performs URL rewriting.
+     * <p/>
+     * E.g. If the reverse proxy rewrites / to /my-application, and the path config property is `redoc`, then this
+     * routing-base-path property should be set to `/my-application/q/redoc`.
+     */
+    @ConfigDocDefault("Defaults to the resolved path (e.g., /q/redoc)")
+    Optional<String> routingBasePath();
+
+    /**
      * The title displayed in the browser tab.
      */
     @WithDefault("API Documentation")

--- a/deployment/src/main/java/io/quarkiverse/redoc/deployment/model/RedocConfigModel.java
+++ b/deployment/src/main/java/io/quarkiverse/redoc/deployment/model/RedocConfigModel.java
@@ -10,6 +10,7 @@ import io.quarkiverse.redoc.deployment.config.Layout;
  */
 public record RedocConfigModel(
         String path,
+        String routingBasePath,
         String title,
         boolean alwaysInclude,
         Boolean hideDownloadButtons,

--- a/deployment/src/main/resources/templates/redoc.html
+++ b/deployment/src/main/resources/templates/redoc.html
@@ -14,9 +14,36 @@
 <body>
     <div id="redoc-container"></div>
 
+    <script>
+        const specUrl = '{specUrl}';
+        const redocOptions = {redocOptions};
+    </script>
+    <script>
+        // Workaround: Override History API to keep base path at the configured routingBasePath
+        // routingBasePath causes redocly not to load anymore in 3.0.0.rc0
+        const routingBasePath = redocOptions.routingBasePath;
+        redocOptions.routingBasePath = null;
+
+        const originalPushState = history.pushState.bind(history);
+        const originalReplaceState = history.replaceState.bind(history);
+
+        history.pushState = function(state, title, url) {
+            if (url && !url.startsWith(routingBasePath)) {
+                url = routingBasePath + (url.startsWith('/') ? '' : '/') + url;
+            }
+            return originalPushState(state, title, url);
+        };
+
+        history.replaceState = function(state, title, url) {
+            if (url && !url.startsWith(routingBasePath)) {
+                url = routingBasePath + (url.startsWith('/') ? '' : '/') + url;
+            }
+            return originalReplaceState(state, title, url);
+        };
+    </script>
     <script type="module">
         import { init } from '{redocJsPath}';
-        init('{specUrl}', {redocOptions}, document.getElementById('redoc-container'))
+        init(specUrl, redocOptions, document.getElementById('redoc-container'))
     </script>
 </body>
 </html>

--- a/deployment/src/test/java/io/quarkiverse/redoc/test/AbstractRedocConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/redoc/test/AbstractRedocConfigTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 public abstract class AbstractRedocConfigTest {
 
     private static final Pattern REDOC_OPTIONS_PATTERN = Pattern.compile(
-            "init\\('[^']*',\\s*(\\{.*?})\\s*,\\s*document\\.getElementById",
+            "const redocOptions = (\\{.*?});",
             Pattern.DOTALL);
 
     protected abstract String getConfigPath();

--- a/deployment/src/test/resources/config/all-false/expected.json
+++ b/deployment/src/test/resources/config/all-false/expected.json
@@ -1,4 +1,5 @@
 {
+  "routingBasePath": "/q/redoc",
   "hideDownloadButtons": false,
   "hideSchemaTitles": false,
   "jsonSamplesExpandLevel": 2,

--- a/deployment/src/test/resources/config/all-true/expected.json
+++ b/deployment/src/test/resources/config/all-true/expected.json
@@ -1,4 +1,5 @@
 {
+  "routingBasePath": "/q/redoc",
   "hideDownloadButtons": true,
   "hideSchemaTitles": true,
   "jsonSamplesExpandLevel": "all",

--- a/deployment/src/test/resources/config/defaults/expected.json
+++ b/deployment/src/test/resources/config/defaults/expected.json
@@ -1,4 +1,5 @@
 {
+  "routingBasePath": "/q/redoc",
   "downloadUrls": [
     {"title": "JSON", "url": "/q/openapi.json"},
     {"title": "YAML", "url": "/q/openapi.yaml"}

--- a/docs/modules/ROOT/pages/includes/quarkus-redoc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-redoc.adoc
@@ -28,6 +28,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++redoc+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-redoc_quarkus-redoc-routing-base-path]] [.property-path]##link:#quarkus-redoc_quarkus-redoc-routing-base-path[`quarkus.redoc.routing-base-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.redoc.routing-base-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The base path of Redocly, combined with any other preceding path. Redocly performs URL manipulation when navigating to OpenAPI tags using the sidebar.
+
+Useful if this Quarkus application is served behind a reverse proxy which performs URL rewriting.
+
+E.g. If the reverse proxy rewrites / to /my-application, and the path config property is `redoc`, then this routing-base-path property should be set to `/my-application/q/redoc`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_REDOC_ROUTING_BASE_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_REDOC_ROUTING_BASE_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Defaults to the resolved path (e.g., /q/redoc)+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-redoc_quarkus-redoc-title]] [.property-path]##link:#quarkus-redoc_quarkus-redoc-title[`quarkus.redoc.title`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.redoc.title+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-redoc_quarkus.redoc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-redoc_quarkus.redoc.adoc
@@ -28,6 +28,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++redoc+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-redoc_quarkus-redoc-routing-base-path]] [.property-path]##link:#quarkus-redoc_quarkus-redoc-routing-base-path[`quarkus.redoc.routing-base-path`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.redoc.routing-base-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The base path of Redocly, combined with any other preceding path. Redocly performs URL manipulation when navigating to OpenAPI tags using the sidebar.
+
+Useful if this Quarkus application is served behind a reverse proxy which performs URL rewriting.
+
+E.g. If the reverse proxy rewrites / to /my-application, and the path config property is `redoc`, then this routing-base-path property should be set to `/my-application/q/redoc`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_REDOC_ROUTING_BASE_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_REDOC_ROUTING_BASE_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++Defaults to the resolved path (e.g., /q/redoc)+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-redoc_quarkus-redoc-title]] [.property-path]##link:#quarkus-redoc_quarkus-redoc-title[`quarkus.redoc.title`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.redoc.title+++[]


### PR DESCRIPTION
currently, when clicking on the schemaDefinitionsTagName, redocly apperantly uses / as base path instead of the current base path the page is served from.
redocly offers a config option for this, routingBasePath. However, setting this options causes 3.0.0.rc0 to not load anymore. 

So for now, lets just hook into the history api, and intercept the history changes caused by redocly. 

We now ensure ourselves the uri stays in /q/redoc (or whatever configured).
This also add the routingBasePath option itself, so that later on we can switch to just use the option directly.